### PR TITLE
Make it possible to compare 'mssql_include' columns on indexes in the autogenerate code

### DIFF
--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -693,6 +693,15 @@ def _compare_indexes_and_uniques(
                 msg.append(
                     " columns %r to %r" % (conn_obj.sig, metadata_obj.sig)
                 )
+            if 'mssql' in conn_obj.const.dialect_options:
+                conn_included_columns = conn_obj.const.dialect_options['mssql'].get('include', None) or []
+                if conn_included_columns:
+                    metadata_included_columns = tuple(sorted(metadata_obj.const.dialect_options.get('mssql', {}).get('include', None) or []))
+                    conn_included_columns = tuple(sorted(conn_included_columns))
+                    if conn_obj.sig != metadata_obj.sig:
+                        msg.append(
+                            " MSSQL included columns %r to %r" % (metadata_included_columns, conn_included_columns)
+                        )
 
             if msg:
                 obj_changed(conn_obj, metadata_obj, msg)

--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -370,7 +370,10 @@ class _ix_constraint_sig(_constraint_sig):
     def __init__(self, const):
         self.const = const
         self.name = const.name
-        self.sig = tuple(sorted([col.name for col in const.columns]))
+        colnames = [col.name for col in const.columns]
+        if 'mssql' in const.dialect_options:
+            colnames.extend(const.dialect_options['mssql'].get('include', None) or [])
+        self.sig = tuple(sorted(colnames))
         self.is_unique = bool(const.unique)
 
     def md_name_to_sql_name(self, context):

--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -233,7 +233,7 @@ def _make_index(params, conn_table):
     ix = sa_schema.Index(
         params["name"],
         *[conn_table.c[cname] for cname in params["column_names"]],
-        unique=params["unique"]
+        **dict(list(params.get("dialect_options", {}).items()) + [('unique', params["unique"])])
     )
     if "duplicates_constraint" in params:
         ix.info["duplicates_constraint"] = params["duplicates_constraint"]

--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -695,7 +695,7 @@ def _compare_indexes_and_uniques(
                 if conn_included_columns:
                     metadata_included_columns = tuple(sorted(metadata_obj.const.dialect_options.get('mssql', {}).get('include', None) or []))
                     conn_included_columns = tuple(sorted(conn_included_columns))
-                    if conn_obj.sig != metadata_obj.sig:
+                    if conn_included_columns != metadata_included_columns:
                         msg.append(
                             " MSSQL included columns %r to %r" % (metadata_included_columns, conn_included_columns)
                         )

--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -370,10 +370,7 @@ class _ix_constraint_sig(_constraint_sig):
     def __init__(self, const):
         self.const = const
         self.name = const.name
-        colnames = [col.name for col in const.columns]
-        if 'mssql' in const.dialect_options:
-            colnames.extend(const.dialect_options['mssql'].get('include', None) or [])
-        self.sig = tuple(sorted(colnames))
+        self.sig = tuple(sorted([col.name for col in const.columns]))
         self.is_unique = bool(const.unique)
 
     def md_name_to_sql_name(self, context):


### PR DESCRIPTION
This required two changes - the first was to add the 'include' list from the mssql dialect options to the column list that is used as the 'sig' for an index, and the second was to actually use the dialect options that are returned from the sqlalchemy reflection api when creating and Index object.