### PR TITLE
Check the dialect name is mssql when checking include_columns

### DIFF
--- a/alembic/__init__.py
+++ b/alembic/__init__.py
@@ -6,7 +6,7 @@ from . import op  # noqa
 from .runtime import environment
 from .runtime import migration
 
-__version__ = '1.0.7+j5.1'
+__version__ = '1.0.7+j5.2'
 
 package_dir = path.abspath(path.dirname(__file__))
 

--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -690,15 +690,13 @@ def _compare_indexes_and_uniques(
                 msg.append(
                     " columns %r to %r" % (conn_obj.sig, metadata_obj.sig)
                 )
-            if 'mssql' in conn_obj.const.dialect_options:
-                conn_included_columns = conn_obj.const.dialect_options['mssql'].get('include', None) or []
-                if conn_included_columns:
-                    metadata_included_columns = tuple(sorted(metadata_obj.const.dialect_options.get('mssql', {}).get('include', None) or []))
-                    conn_included_columns = tuple(sorted(conn_included_columns))
-                    if conn_included_columns != metadata_included_columns:
-                        msg.append(
-                            " MSSQL included columns %r to %r" % (metadata_included_columns, conn_included_columns)
-                        )
+            if autogen_context.dialect.name == 'mssql':
+                conn_included_columns = tuple(sorted(conn_obj.const.dialect_options.get('mssql', {}).get('include', None) or []))
+                metadata_included_columns = tuple(sorted(metadata_obj.const.dialect_options.get('mssql', {}).get('include', None) or []))
+                if conn_included_columns != metadata_included_columns:
+                    msg.append(
+                        " MSSQL included columns %r to %r" % (metadata_included_columns, conn_included_columns)
+                    )
 
             if msg:
                 obj_changed(conn_obj, metadata_obj, msg)

--- a/docs/build/changelog.rst
+++ b/docs/build/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 ==========
 
 .. changelog::
-    :version: 1.0.7+j5.1
+    :version: 1.0.7+j5.2
     :released: February 11, 2019
 
     .. change::


### PR DESCRIPTION
This updates to rather check the dialect name, otherwise if there
aren't any include columns in the existing DB, and there are in
the metadata, then it won't detect that.